### PR TITLE
Extract BUILD correctly when TAG has digits

### DIFF
--- a/libexec/functions.d/buildfunctions.sh
+++ b/libexec/functions.d/buildfunctions.sh
@@ -136,7 +136,7 @@ function build_item_packages
     else
       # If there are multiple packages from one SlackBuild, and they all have
       # different BUILD numbers, frankly we are screwed, so just use the first:
-      oldbuild=$(echo "${oldpkgs[0]}" | sed -e 's/^.*-//' -e 's/[^0-9]*$//' )
+      oldbuild=$(echo "${oldpkgs[0]}" | sed -e 's/^.*-//' -e 's/^\([[:digit:]][[:digit:]]*\).*$/\1/')
     fi
     backuppkgs=( "$SR_PKGBACKUP"/"$itemdir"/*.t?z )
     if [ "${backuppkgs[0]}" != "$SR_PKGBACKUP"/"$itemdir"/'*.t?z' ]; then


### PR DESCRIPTION
When comparing the last BUILD to the current, `build_item_packages` was
extracing BUILD with:

`sed -e 's/^.*-//' -e 's/[^0-9]*$//'`

A typical TAG of _tag or _acl would be stripped properly, but something
like _sl14.2acl would only result in _sl14.2 along with the leading
BUILD.

I have updated it to capture leading digits and strip from the first
non-digit.

`sed -e 's/^.*-//' -e 's/^\([[:digit:]][[:digit:]]*\).*$/\1/'`