### PR TITLE
Fix DELREQUIRES

### DIFF
--- a/libexec/functions.d/parsefunctions.sh
+++ b/libexec/functions.d/parsefunctions.sh
@@ -578,10 +578,16 @@ function parse_info_and_hints
     # (1) Remove DELREQUIRES and %README%
     local delreq req newreqlist
     newreqlist=""
-    for delreq in ${DELREQUIRES} '%README%'; do
-      for req in ${INFOREQUIRES[$itemid]}; do
-        [ "$req" != "$delreq" ] && newreqlist="$newreqlist $req"
+    for req in ${INFOREQUIRES[$itemid]}; do
+      for delreq in ${DELREQUIRES} '%README%'; do
+        if [ "$req" == "$delreq" ] ; then
+         req=""
+         break
+        fi
       done
+      if [ -n "$req" ] ; then
+        newreqlist="$newreqlist $req"
+      fi
     done
     INFOREQUIRES[$itemid]="$(echo ${newreqlist})"
 


### PR DESCRIPTION
When DELREQUIRES is specified, the old algorithm's double for-loop did
not actually remove any of the DELREQUIRES entries from the REQUIRES
list.  Switch the logic of the double for-loop around so that every item
in INFOREQUIRES is tested against the entire list of DELREQUIRES (and
'%README%'), and only when it never matches then add it to newreqlist.

The "break" statement in the inner for-loop is an optimization and not
strictly needed.  It bails out of the inner for-loop as soon as we've
found a match in the DELREQUIRES (or '%README%') list.